### PR TITLE
adicionar overlay escuro ao abrir popups

### DIFF
--- a/blocks/overlay.css
+++ b/blocks/overlay.css
@@ -1,0 +1,23 @@
+.overlay {
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.6);
+  z-index: 10;
+}
+
+.overlay.ativo {
+  opacity: 1;
+  visibility: visible;
+}
+
+.popup,
+.popup__cartao,
+.popup-imagem {
+  z-index: 20;
+}

--- a/blocks/popup.css
+++ b/blocks/popup.css
@@ -4,6 +4,7 @@
   right: 0;
   left: 0;
   bottom: 0;
+
   display: none;
   justify-content: center;
   align-items: center;
@@ -11,6 +12,7 @@
 
 .popup__relative {
   max-width: 430px;
+
   width: 100%;
   margin: 0 auto;
   display: flex;

--- a/blocks/popupcartao.css
+++ b/blocks/popupcartao.css
@@ -3,6 +3,7 @@
   top: 0;
   right: 0;
   left: 0;
+
   bottom: 0;
   display: none;
   justify-content: center;

--- a/index.html
+++ b/index.html
@@ -48,12 +48,28 @@
         </section>
         <section class="main__grid"></section>
       </div>
+
       <footer class="footer">
         <div class="footer__footer">
           <p class="footer__texto">© 2025 Around The U.S.</p>
         </div>
       </footer>
     </div>
+
+    <div class="popup-imagem">
+      <div class="popup-imagem-conteudo">
+        <button class="popup-imagem-close">
+          <img
+            src="./images/Close-Icon.png"
+            class="popup-imagem__close-img"
+            alt="Fechar"
+          />
+        </button>
+        <img class="popup__img" src="" alt="" />
+        <p class="popup-imagem-titulo"></p>
+      </div>
+    </div>
+
     <div class="popup">
       <div class="popup__relative">
         <div class="popup__button-conteiner">
@@ -95,6 +111,7 @@
         </div>
       </div>
     </div>
+
     <div class="popup__cartao">
       <div class="popup__relative-cartao">
         <div class="popup__button-cartao">

--- a/pages/index.css
+++ b/pages/index.css
@@ -9,3 +9,4 @@
 @import url(../blocks/popup.css);
 @import url(../blocks/popupcartao.css);
 @import url(../blocks/popupimagem.css);
+@import url(../blocks/overlay.css);

--- a/scripts/card.js
+++ b/scripts/card.js
@@ -3,17 +3,19 @@ export class Card {
   _title;
   _imageLink;
   _templateSelector;
+  _handleImageClick;
 
-  constructor(title, imageLink, templateSelector) {
+  constructor(title, imageLink, templateSelector, handleImageClick) {
     this._title = title;
     this._imageLink = imageLink;
     this._templateSelector = templateSelector;
+    this._handleImageClick = handleImageClick;
   }
 
   // Método público que retorna o card pronto com eventos
   getCardElement() {
-    const cardElement = this._createCardElement(); // Cria o HTML do card
-    this._addEventListeners(cardElement); // Adiciona eventos ao card
+    const cardElement = this._createCardElement();
+    this._addEventListeners(cardElement);
     return cardElement;
   }
 
@@ -79,7 +81,9 @@ export class Card {
 
     // Clique na imagem abre o popup
     imagem.addEventListener("click", () => {
-      this._handleImageClick();
+      if (this._handleImageClick) {
+        this._handleImageClick(this._title, this._imageLink);
+      }
     });
 
     // Clique no botão de deletar remove o card
@@ -94,21 +98,10 @@ export class Card {
   }
 
   //------------------------ Ações dos botões ------------------------//
-
-  // Mostra a imagem em destaque no popup
-  _handleImageClick() {
-    popupImagem.classList.add("popup-imagem-ativa");
-    popupImagemImg.src = this._imageLink;
-    popupImagemImg.alt = this._title;
-    popupImagemTitulo.textContent = this._title;
-  }
-
-  // Remove o card do DOM
   _handleDelete(cardElement) {
     cardElement.remove();
   }
 
-  // Alterna o estado de curtida e retorna o novo estado
   _handleLike(botaoLike, curtido) {
     botaoLike.innerHTML = curtido
       ? '<img src="./images/Vector (1).svg" alt="Curtir">'

--- a/scripts/formValidator.js
+++ b/scripts/formValidator.js
@@ -19,7 +19,7 @@ export class FormValidator {
       this._submitButtonSelector
     );
 
-    this._setEventListeners(); // Define os ouvintes de eventos
+    this._setEventListeners();
   }
 
   //------------------------ Listeners de Input ------------------------//
@@ -28,8 +28,8 @@ export class FormValidator {
 
     this._inputList.forEach((input) => {
       input.addEventListener("input", () => {
-        this._checkInputValidity(input); // Valida o input atual
-        this._toggleButtonState(); // Atualiza o botão
+        this._checkInputValidity(input);
+        this._toggleButtonState();
       });
     });
   }

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -19,7 +19,7 @@ const textoPerfil = document.querySelector(".main__interacao-texto");
 
 const popupCartao = document.querySelector(".popup__cartao");
 const buttonOpen1 = document.getElementById("botao");
-const closeButton1 = document.querySelector(".popup__close-img");
+const closeButton1 = document.querySelector(".popup__close-cartaobuttonimg");
 const buttonCriar = document.querySelector(".popup__close-cartaobutton");
 
 const mainGrid = document.querySelector(".main__grid");
@@ -51,6 +51,19 @@ const validatorCartao = new FormValidator(
 validatorPerfil.enableValidation();
 validatorCartao.enableValidation();
 
+//------------------------ CRIAÇÃO DO OVERLAY ------------------------//
+const overlay = document.createElement("div");
+overlay.classList.add("overlay");
+document.body.appendChild(overlay);
+
+function showOverlay() {
+  overlay.classList.add("ativo");
+}
+
+function hideOverlay() {
+  overlay.classList.remove("ativo");
+}
+
 //------------------------ CRIAÇÃO DO POPUP DE IMAGEM ------------------------//
 const popupImagem = document.createElement("div");
 popupImagem.classList.add("popup-imagem");
@@ -73,18 +86,22 @@ function openPopup() {
   popup.classList.add("popup__relative");
   inputNome.value = tituloPerfil.textContent;
   inputProfissao.value = textoPerfil.textContent;
+  showOverlay();
 }
 
 function closePopup() {
   popup.classList.remove("popup__relative");
+  hideOverlay();
 }
 
 function openCartao() {
   popupCartao.classList.add("popup__relative-cartao");
+  showOverlay();
 }
 
 function closeCartao() {
   popupCartao.classList.remove("popup__relative-cartao");
+  hideOverlay();
 }
 
 //------------------------ FECHAR POPUPS AO CLICAR FORA ------------------------//
@@ -110,6 +127,7 @@ document.addEventListener("click", function (event) {
     !popupImagem.querySelector(".popup-imagem-conteudo").contains(event.target)
   ) {
     popupImagem.classList.remove("popup-imagem-ativa");
+    hideOverlay();
   }
 });
 
@@ -120,9 +138,18 @@ popupImagem
   .querySelector(".popup-imagem-conteudo")
   .addEventListener("click", (event) => event.stopPropagation());
 
+//------------------------ FUNÇÃO PARA ABRIR A IMAGEM ------------------------/
+function handleCardClick(name, link) {
+  popupImagemImg.src = link;
+  popupImagemImg.alt = name;
+  popupImagemTitulo.textContent = name;
+  popupImagem.classList.add("popup-imagem-ativa");
+  showOverlay();
+}
+
 //------------------------ FUNÇÃO PARA ADICIONAR IMAGEM ------------------------//
 function adicionarImagem(link, titulo) {
-  const card = new Card(titulo, link, ".container");
+  const card = new Card(titulo, link, ".container", handleCardClick);
   const cardElement = card.getCardElement();
   mainGrid.appendChild(cardElement);
 
@@ -161,7 +188,12 @@ const initialCards = [
 //------------------------ FUNÇÃO PARA CARREGAR IMAGENS INICIAIS ------------------------//
 function carregarImagensIniciais() {
   initialCards.forEach((cardData) => {
-    const card = new Card(cardData.name, cardData.link, ".container");
+    const card = new Card(
+      cardData.name,
+      cardData.link,
+      ".container",
+      handleCardClick
+    );
     const cardElement = card.getCardElement();
     mainGrid.appendChild(cardElement);
   });
@@ -182,11 +214,13 @@ function salvarPopup(event) {
 //------------------------ EVENTOS DO POPUP DE IMAGEM ------------------------//
 popupImagemClose.addEventListener("click", () => {
   popupImagem.classList.remove("popup-imagem-ativa");
+  hideOverlay();
 });
 
 popupImagem.addEventListener("click", (event) => {
   if (event.target === popupImagem) {
     popupImagem.classList.remove("popup-imagem-ativa");
+    hideOverlay();
   }
 });
 
@@ -217,5 +251,6 @@ document.addEventListener("keydown", function (event) {
     closePopup();
     closeCartao();
     popupImagem.classList.remove("popup-imagem-ativa");
+    hideOverlay();
   }
 });


### PR DESCRIPTION
adicionar overlay escuro ao abrir popups

Foi implementado um elemento overlay que cobre toda a tela com fundo escuro semi-transparente (rgba) sempre que um popup é aberto. Isso melhora a experiência do usuário, destacando o conteúdo do popup e reduzindo distrações visuais.

O overlay é exibido e escondido dinamicamente com transições suaves, e funciona tanto para o popup de perfil quanto para o popup de adicionar novo local e visualização de imagem.

Adições:
- Novo elemento `<div class="overlay">` adicionado ao HTML
- Estilo CSS para `.overlay` com `opacity` e `transition`
- Lógica no JavaScript para controlar visibilidade do overlay